### PR TITLE
remove-unnecessary-print-from-get-record-method

### DIFF
--- a/IP2Proxy.py
+++ b/IP2Proxy.py
@@ -529,8 +529,8 @@ class IP2Proxy(object):
         low = 0
         ipv = self._parse_addr(ip)[0] 
         ipnum = self._parse_addr(ip)[1]
-        print (ipv)
-        print (ipnum)
+        # print (ipv)
+        # print (ipnum)
         if (ipv == 0):
             rec = IP2ProxyRecord()
             rec.country_short = _INVALID_IP_ADDRESS


### PR DESCRIPTION
while i was using this library, I found that when I call get_all() or any other funciton which uses the _get_record() method, prints some values with return value and When I saw the code I found that there is "ipv" and "ipnum" variables which is printing these values with return value so I tried to fix it to put it into comment 